### PR TITLE
fix: add reference types

### DIFF
--- a/cypress/integration/tests/sample_test.js
+++ b/cypress/integration/tests/sample_test.js
@@ -1,3 +1,5 @@
+/// <reference types="cypress" />
+
 describe ('Search for Leapfrog technology ', () =>{
     
     it("should visit Google Homepage", () => {


### PR DESCRIPTION
Will ensure that cypress has type checks when tests are run